### PR TITLE
Fix HAVE_CLOCK_MONOTONIC detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,8 +163,12 @@ AC_TRY_COMPILE([
   #include <time.h>
   #include <errno.h>
 ],[
-  struct timespec tp;
-  clock_gettime(CLOCK_MONOTONIC, &tp);
+  struct timespec tm;
+  struct timespec rem;
+  tm.tv_sec = *t / 1000000;
+  tm.tv_nsec = (*t % 1000000)*1000;
+  clock_nanosleep(CLOCK_MONOTONIC, 0,
+                        &tm, &rem);
   ],
   [
     # program could be run


### PR DESCRIPTION
Use the code snipped from time.c that is affected by HAVE_CLOCK_MONOTONIC for the detection. This especially meant to fix the detection for macOS builds