### PR TITLE
Fix various typos in the codebase

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 The gavl core was written by me (Burkhard Plaum). Many
-converison routines are, however taken from other (L)GLPed
+conversion routines are, however taken from other (L)GLPed
 projects (most notably avifile, MPlayer and xine).
 
 Audio dithering is done by the included libgdither by Steve Harris. 

--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ dnl
 
 AC_C_ATTRIBUTE_ALIGNED
 
-AC_C_BIGENDIAN(,,AC_MSG_ERROR("Cannot detect endianess"))
+AC_C_BIGENDIAN(,,AC_MSG_ERROR("Cannot detect endianness"))
 
 LIBGAVL_CFLAGS=""
 case "$host_os" in 

--- a/gavl/arith128.c
+++ b/gavl/arith128.c
@@ -28,7 +28,7 @@
  * which are part of gnucash (http://gnucash.org). 
  *
  * Seems the gnucash people are prepared for hyperinflation with
- * their 128 bit arithmetics :)
+ * their 128 bit arithmetic :)
  */
 
 #include <inttypes.h>

--- a/gavl/audiosource.c
+++ b/gavl/audiosource.c
@@ -345,7 +345,7 @@ read_frame_internal(void * sp, gavl_audio_frame_t ** frame, int num_samples)
   while(samples_read < num_samples)
     {
     
-    /* Read new frame if neccesary */
+    /* Read new frame if necessary */
     if(!s->frame || !s->frame->valid_samples)
       {
       eat_all = 0;

--- a/gavl/c/blend_c.c
+++ b/gavl/c/blend_c.c
@@ -200,7 +200,7 @@ static void blend_graya_16(gavl_overlay_blend_context_t * ctx,
       else if(ovl_ptr[1])
         {
         /* rgba -> rgba blending */
-        /* Due to the complicated arithmetics, this is
+        /* Due to the complicated arithmetic, this is
            done in floating point. High speed integer versions
            are welcome */
 
@@ -259,7 +259,7 @@ static void blend_graya_32(gavl_overlay_blend_context_t * ctx,
       else if(ovl_ptr[1])
         {
         /* rgba -> rgba blending */
-        /* Due to the complicated arithmetics, this is
+        /* Due to the complicated arithmetic, this is
            done in floating point. High speed integer versions
            are welcome */
 
@@ -320,7 +320,7 @@ static void blend_graya_float(gavl_overlay_blend_context_t * ctx,
       else if(ovl_ptr[1] != 0.0)
         {
         /* rgba -> rgba blending */
-        /* Due to the complicated arithmetics, this is
+        /* Due to the complicated arithmetic, this is
            done in floating point. High speed integer versions
            are welcome */
 
@@ -751,7 +751,7 @@ static void blend_rgba_32(gavl_overlay_blend_context_t * ctx,
       else if(ovl_ptr[3])
         {
         /* rgba -> rgba blending */
-        /* Due to the complicated arithmetics, this is
+        /* Due to the complicated arithmetic, this is
            done in floating point. High speed integer versions
            are welcome */
 
@@ -872,7 +872,7 @@ static void blend_rgba_64(gavl_overlay_blend_context_t * ctx,
       else if(ovl_ptr[3])
         {
         /* rgba -> rgba blending */
-        /* Due to the complicated arithmetics, this is
+        /* Due to the complicated arithmetic, this is
            done in floating point. High speed integer versions
            are welcome */
 
@@ -1147,7 +1147,7 @@ static void blend_yuva_32(gavl_overlay_blend_context_t * ctx,
       else if(ovl_ptr[3])
         {
         /* rgba -> rgba blending */
-        /* Due to the complicated arithmetics, this is
+        /* Due to the complicated arithmetic, this is
            done in floating point. High speed integer versions
            are welcome */
 

--- a/gavl/colorspace.c
+++ b/gavl/colorspace.c
@@ -4436,12 +4436,12 @@ int gavl_pixelformat_conversion_penalty(gavl_pixelformat_t src,
 
   ret = 0;
   
-  /* Loosing the color is the worst */
+  /* Losing the color is the worst */
   if(!gavl_pixelformat_is_gray(src) &&
      gavl_pixelformat_is_gray(dst))
     ret += 1;
   
-  /* Loosing the alpha channel is second worst */
+  /* Losing the alpha channel is second worst */
   ret <<= 1;
   if(gavl_pixelformat_has_alpha(src) &&
      !gavl_pixelformat_has_alpha(dst))
@@ -4481,7 +4481,7 @@ int gavl_pixelformat_conversion_penalty(gavl_pixelformat_t src,
   /* Increasing precision is bad... */
   if(src_bits < dst_bits)
     ret += (dst_bits - src_bits);
-  /* ... but descreasing precision is worse */
+  /* ... but decreasing precision is worse */
   else if(src_bits > dst_bits)
     ret += (src_bits - dst_bits) * 2;
 

--- a/gavl/dsputils.c
+++ b/gavl/dsputils.c
@@ -486,7 +486,7 @@ gavl_dsp_video_frame_shuffle_4(gavl_dsp_context_t * ctx, gavl_video_frame_t * fr
                                const gavl_video_format_t * format, int * src_indices)
   {
   //  gavl_dsp_video_frame_shuffle_4_copy(ctx, frame, frame, format, src_indices);
-  fprintf(stderr, "gavl_dsp_video_frame_shuffle_4 Not implemeted\n");
+  fprintf(stderr, "gavl_dsp_video_frame_shuffle_4 Not implemented\n");
   }
 
 void

--- a/gavl/httpclient.c
+++ b/gavl/httpclient.c
@@ -850,7 +850,7 @@ static int prepare_connection(gavl_io_t * io,
     if(strcmp(host, c->host))
       {
       do_close = 1;
-      gavl_log(GAVL_LOG_INFO, LOG_DOMAIN, "Closing keepalive connection (host changed fromm %s to %s)",
+      gavl_log(GAVL_LOG_INFO, LOG_DOMAIN, "Closing keepalive connection (host changed from %s to %s)",
                c->host, host);
       }
     else if(strcmp(protocol, c->protocol))
@@ -899,7 +899,7 @@ static int prepare_connection(gavl_io_t * io,
   if(c->io_int)
     {
     ret = 1;
-    gavl_log(GAVL_LOG_DEBUG, LOG_DOMAIN, "Re-using keepalive connection");
+    gavl_log(GAVL_LOG_DEBUG, LOG_DOMAIN, "Reusing keepalive connection");
     c->flags |= FLAG_USE_KEEPALIVE;
     goto end;
     }

--- a/gavl/hw.c
+++ b/gavl/hw.c
@@ -267,10 +267,10 @@ types[] =
     // EGL Texture (associated with X11 connection)
     { GAVL_HW_EGL_GLES, "Opengl ES Texture (EGL)", "gles" },
 
-    // V4L2 buffers (mmap()ed, optionaly also with DMA handles)
+    // V4L2 buffers (mmap()ed, optionally also with DMA handles)
     { GAVL_HW_V4L2_BUFFER, "V4L2 Buffer", "v4l2" }, 
 
-    // DMA handles, can be exported by V4L and im- and exported by OpenGL and also mmaped to userspace
+    // DMA handles, can be exported by V4L and im- and exported by OpenGL and also mmapped to userspace
     { GAVL_HW_DMABUFFER,   "DMA Buffer", "dmabuf" },
 
     // Shared memory, which can be sent to other processes

--- a/gavl/hw_dmabuf.c
+++ b/gavl/hw_dmabuf.c
@@ -837,7 +837,7 @@ static int bpp_supported(int drm_fd, int bpp)
   struct drm_mode_destroy_dumb destroy_req = {0};
   int ret;
   
-  // Prepare rquest
+  // Prepare request
   create_req.width  = 64;
   create_req.height = 64;
   create_req.bpp = bpp;

--- a/gavl/hw_egl.c
+++ b/gavl/hw_egl.c
@@ -417,7 +417,7 @@ uint32_t * gavl_hw_ctx_egl_get_dma_import_formats(gavl_hw_context_t * ctx)
     else
       {
 #if 0
-      fprintf(stderr, "Suported format: %c%c%c%c -> %s\n",
+      fprintf(stderr, "Supported format: %c%c%c%c -> %s\n",
               (formats[i] >> 0) & 0xff,
               (formats[i] >> 8) & 0xff,
               (formats[i] >> 16) & 0xff,

--- a/gavl/hw_v4l2.c
+++ b/gavl/hw_v4l2.c
@@ -232,7 +232,7 @@ capabilities[] =
    { V4L2_CAP_VIDEO_OVERLAY, "Overlay" },                   // Can do video overlay
    { V4L2_CAP_VBI_CAPTURE,   "VBI Capture" },               // Is a raw VBI capture device
    { V4L2_CAP_VBI_OUTPUT,    "VBO Output" },                // Is a raw VBI output device
-   { V4L2_CAP_SLICED_VBI_CAPTURE, "Sliced VBI Capture" },   // Is a sliced VBI capture devic
+   { V4L2_CAP_SLICED_VBI_CAPTURE, "Sliced VBI Capture" },   // Is a sliced VBI capture device
    { V4L2_CAP_SLICED_VBI_OUTPUT,  "Sliced VBI Output" },    // Is a sliced VBI output device
    { V4L2_CAP_RDS_CAPTURE, "RDS Capture"  },                // RDS data capture
    { V4L2_CAP_VIDEO_OUTPUT_OVERLAY, "Output Overlay" },     // Can do video output overlay
@@ -1941,7 +1941,7 @@ static int check_str(const gavl_v4l2_device_t * dev,
   
   if(!str_to_int(map, str, &id))
     {
-    gavl_log(GAVL_LOG_ERROR, LOG_DOMAIN, "Unkown %s: %s", var,
+    gavl_log(GAVL_LOG_ERROR, LOG_DOMAIN, "Unknown %s: %s", var,
              str);
     return 0;
     }
@@ -3501,7 +3501,7 @@ static int can_export_v4l2(gavl_hw_context_t * ctx, const gavl_hw_context_t * to
       
       if(port->current_buf->buf.memory != V4L2_MEMORY_MMAP)
         {
-        gavl_log(GAVL_LOG_INFO, LOG_DOMAIN, "DMABUF export not supported (no mmaped buffers)");
+        gavl_log(GAVL_LOG_INFO, LOG_DOMAIN, "DMABUF export not supported (no mmapped buffers)");
         return 0;
         }
 

--- a/gavl/libgdither/gdither.c
+++ b/gavl/libgdither/gdither.c
@@ -409,7 +409,7 @@ void gdither_runf(GDither s, unsigned int channel, unsigned int length,
         return;
     }
 
-    /* some common case handling code - looks a bit wierd, but it allows
+    /* some common case handling code - looks a bit weird, but it allows
      * the compiler to optiomise out the branches in the inner loop */
     if (s->bit_depth == 8 && s->dither_depth == 8) {
 	switch (s->type) {

--- a/gavl/libgdither/gdither.h
+++ b/gavl/libgdither/gdither.h
@@ -55,7 +55,7 @@ extern "C" {
  *
  * The Dither type is one of
  *
- *   GDitherNone - straight nearest neighbour rounding. Theres no pressing
+ *   GDitherNone - straight nearest neighbour rounding. There's no pressing
  *   reason to do this at 8 or 16 bit, but you might want to at 24, for some
  *   reason. At the lest it will save you writing int->float conversion code,
  *   which is arder than it sounds.
@@ -76,7 +76,7 @@ extern "C" {
  *
  * bit depth, sets the bit width of the output sample data, it can be one of:
  *
- *   GDither8bit   - 8 bit unsiged
+ *   GDither8bit   - 8 bit unsigned
  *   GDither16bit  - 16 bit signed
  *   GDither32bit  - 24+bits in upper bits of a 32 bit word
  *   GDitherFloat  - IEEE floating point (32bits)

--- a/gavl/libgdither/gdither_types_internal.h
+++ b/gavl/libgdither/gdither_types_internal.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GDITHER_SH_BUF_SIZE 8
 #define GDITHER_SH_BUF_MASK 7
 
-/* this must agree with whats in gdither_types.h */
+/* this must agree with what's in gdither_types.h */
 typedef enum {
     GDitherNone = 0,
     GDitherRect,

--- a/gavl/libgdither/noise.h
+++ b/gavl/libgdither/noise.h
@@ -24,7 +24,7 @@
 #ifndef NOISE_H
 #define NOISE_H
 
-/* Can be overrriden with any code that produces whitenoise between 0.0f and
+/* Can be overridden with any code that produces whitenoise between 0.0f and
  * 1.0f, eg (random() / (float)RAND_MAX) should be a good source of noise, but
  * its expensive */
 #ifndef GDITHER_NOISE

--- a/gavl/libsamplerate/check_asm.sh
+++ b/gavl/libsamplerate/check_asm.sh
@@ -19,7 +19,7 @@
 #=======================================================================
 # This short test script compiles the file src_sinc.c into assembler
 # output and the greps the assembler output for the fldcw (FPU Load
-# Control Word) instruction which is very detrimental to the perfromance
+# Control Word) instruction which is very detrimental to the performance
 # of floating point code.
 
 echo -n "    Checking assembler output for bad code : "

--- a/gavl/memcpy.c
+++ b/gavl/memcpy.c
@@ -189,7 +189,7 @@ int d0, d1, d2;
 
 #ifdef HAVE_SSE
 /* SSE note: i tried to move 128 bytes a time instead of 64 but it
-didn't make any measureable difference. i'm using 64 for the sake of
+didn't make any measurable difference. i'm using 64 for the sake of
 simplicity. [MF] */
 static void * sse_memcpy(void * to, const void * from, size_t len)
 {

--- a/gavl/mmx/_rgb_yuv_mmx.c
+++ b/gavl/mmx/_rgb_yuv_mmx.c
@@ -22,7 +22,7 @@
 
 /*
  *  Support for mmxext
- *  this macro procudes another set of
+ *  this macro produces another set of
  *  functions in ../mmxext
  */
 

--- a/gavl/mmx/_yuv_rgb_mmx.c
+++ b/gavl/mmx/_yuv_rgb_mmx.c
@@ -22,7 +22,7 @@
 
 /*
  *  Support for mmxext
- *  this macro procudes another set of
+ *  this macro produces another set of
  *  functions in ../mmxext
  */
 

--- a/gavl/mmx/_yuv_yuv_mmx.c
+++ b/gavl/mmx/_yuv_yuv_mmx.c
@@ -29,7 +29,7 @@
 
 /*
  *   Convert a single scanline from YUY2 to separate planes
- *   preserving the horizonal subsampling.
+ *   preserving the horizontal subsampling.
  *   This macro does practically the same as the LOAD_YUY2
  *   macro in _yuv_rgb_mmx.c
  */

--- a/gavl/mmx/colorspace_mmx.c
+++ b/gavl/mmx/colorspace_mmx.c
@@ -30,7 +30,7 @@
 
 /*
  *  Support for mmxext
- *  this macro procudes another set of
+ *  this macro produces another set of
  *  functions in ../mmxext
  *  I really wonder if this is the only difference between mmx and mmxext
  */

--- a/gavl/mmx/mmx_macros.h
+++ b/gavl/mmx/mmx_macros.h
@@ -30,7 +30,7 @@
 
 /*
  *  Support for mmxext
- *  this macro procudes another set of
+ *  this macro produces another set of
  *  functions in ../mmxext
  */
 

--- a/gavl/mmx/rgb_yuv_mmx.c
+++ b/gavl/mmx/rgb_yuv_mmx.c
@@ -24,7 +24,7 @@
 
 /*
  *  Support for mmxext
- *  this macro procudes another set of
+ *  this macro produces another set of
  *  functions in ../mmxext
  */
 

--- a/gavl/mmx/yuv_rgb_mmx.c
+++ b/gavl/mmx/yuv_rgb_mmx.c
@@ -22,7 +22,7 @@
 
 /*
  *  Support for mmxext
- *  this macro procudes another set of
+ *  this macro produces another set of
  *  functions in ../mmxext
  */
 

--- a/gavl/mmx/yuv_yuv_mmx.c
+++ b/gavl/mmx/yuv_yuv_mmx.c
@@ -33,7 +33,7 @@ static const mmx_t mmx_ff00w =   { 0xff00ff00ff00ff00LL };
 
 /*
  *   Convert a single scanline from YUY2 to separate planes
- *   preserving the horizonal subsampling.
+ *   preserving the horizontal subsampling.
  *   This macro does practically the same as the LOAD_YUY2
  *   macro in _yuv_rgb_mmx.c
  */

--- a/gavl/scale.c
+++ b/gavl/scale.c
@@ -383,7 +383,7 @@ int gavl_video_scaler_init(gavl_video_scaler_t * scaler,
 
   
   
-  /* Align the destination rectangle to the output formtat */
+  /* Align the destination rectangle to the output format */
 
   gavl_pixelformat_chroma_sub(scaler->dst_format.pixelformat, &sub_h_out, &sub_v_out);
   gavl_rectangle_i_align(&opt.dst_rect, sub_h_out, sub_v_out);

--- a/gavl/scale_context.c
+++ b/gavl/scale_context.c
@@ -366,7 +366,7 @@ float get_scale_offset(int src_field, int dst_field,
 
   scale_fac *= chroma_scale_fac;
   
-  /* Different calculation for diffrent interlacing options */
+  /* Different calculation for different interlacing options */
   
   if(src_fields == 1) /* Progressive input -> Progressive */
     {
@@ -685,7 +685,7 @@ int gavl_video_scale_context_init(gavl_video_scale_context_t*ctx,
       gavl_video_scale_table_get_src_indices(&ctx->table_v,
                                              &src_rect_i.y, &src_rect_i.h);
 
-      /* Decide the scale order depending on whats computationally less expensive */
+      /* Decide the scale order depending on what's computationally less expensive */
       /* We calculate the sizes (in pixels) of the temporary frame for both options and
          take the smaller one */
 #if 0 

--- a/gavl/scale_table.c
+++ b/gavl/scale_table.c
@@ -77,12 +77,12 @@ static void convolve_preblur(float * src_1, int src_len_1,
  * src: |   x   |   x   |
  * dst: | x | x | x | x |
  *
- * The table is created in the follwing steps:
+ * The table is created in the following steps:
  *
- * - Calculate the floating point filter coefficiens for each destination pixel
+ * - Calculate the floating point filter coefficients for each destination pixel
  *   
  * - Shift the indixes of the source pixels such that no source pixels are outside
- *   the image. The nonexistant pixels beyond the borders (whose values are needed
+ *   the image. The nonexistent pixels beyond the borders (whose values are needed
  *   for scaling) are assumed to have the same color as the nearest pixel at the
  *   image border
  *
@@ -373,7 +373,7 @@ static void normalize_table(gavl_video_scale_table_t * tab)
       sum += tab->pixels[i].factor_f[j];
 
     /* This is to prevent accidental setting of clipping functions due to
-       rounding errors. For usual applications, it should not be noticable
+       rounding errors. For usual applications, it should not be noticeable
     */
     sum += FLT_EPSILON;
     

--- a/gavl/socketaddress.c
+++ b/gavl/socketaddress.c
@@ -57,7 +57,7 @@
 
 // #define FLAG_LOOKUP_ACTIVE (1<<0)
 
-/* Asychronous host lookup */
+/* Asynchronous host lookup */
 
 struct lookup_async_s
   {
@@ -640,7 +640,7 @@ int gavl_interface_index_from_address(const gavl_socket_address_t * a)
   return ret;
   }
 
-/* Asychronous host lookup */
+/* Asynchronous host lookup */
 
 
 static lookup_async_t * async_create(const char * hostname,

--- a/include/audio.h
+++ b/include/audio.h
@@ -36,8 +36,8 @@ struct gavl_audio_options_s
   {
   /*
    *  Quality setting from 1 to 5 (0 means undefined).
-   *  3 means Standard C routines or accellerated version with
-   *  equal quality. Lower numbers mean accellerated versions with lower
+   *  3 means Standard C routines or accelerated version with
+   *  equal quality. Lower numbers mean accelerated versions with lower
    *  quality.
    */
   int quality;         

--- a/include/gavl/compression.h
+++ b/include/gavl/compression.h
@@ -308,7 +308,7 @@ GAVL_PUBLIC gavl_codec_id_t
 gavl_compression_from_short_name(const char * name);
 
 /** \brief Get the number of compression formats
- *  \returns The number of supported compresion formats
+ *  \returns The number of supported compression formats
  *
  *  Use this with \ref gavl_get_compression to enumerate all
  *  compression formats
@@ -336,7 +336,7 @@ gavl_codec_id_t gavl_get_compression(int index);
 #define GAVL_PACKET_KEYFRAME (1<<2) //!< Packet is a keyframe
 #define GAVL_PACKET_LAST     (1<<3) //!< Packet is the last in the stream (only Xiph codecs need this flag)
 #define GAVL_PACKET_EXT      (1<<4) //!< Packet has extensions (used only in gavf files)
-#define GAVL_PACKET_REF      (1<<5) //!< B-frame used as reference (can't savely be skipped)
+#define GAVL_PACKET_REF      (1<<5) //!< B-frame used as reference (can't safely be skipped)
 #define GAVL_PACKET_NOOUTPUT (1<<6) //!< Packet will produce no decoder output (e.g. VP8 alternate reference)
 
 #define GAVL_PACKET_HAS_FDS  (1<<7) //!< Packet contains file descriptors (can only be sent via UNIX-Sockets)
@@ -415,7 +415,7 @@ typedef struct
  *  This specifies one packet of compressed data.
  *  For video streams, each packet must correspond to a video frame.
  *  For audio streams, each packet must be the smallest unit, which
- *  can be decoded indepentently and for which a duration is known.
+ *  can be decoded independently and for which a duration is known.
  *
  *  The typical usage of a packet is to memset() it to zero in the
  *  beginning. Then for each packet call \ref gavl_packet_alloc

--- a/include/gavl/connectors.h
+++ b/include/gavl/connectors.h
@@ -178,10 +178,10 @@ void gavl_video_source_drain(gavl_video_source_t * s);
  *  \param func Function to get the frames from
  *  \param priv Client data to pass to func
  *  \param src_flags Flags describing the source
- *  \param src preceeding source in the pipeline
+ *  \param src preceding source in the pipeline
  *  \returns A newly created video source
  *
- *  This will take the destination format of the preceeding source
+ *  This will take the destination format of the preceding source
  *  as the input format
  */
 
@@ -208,7 +208,7 @@ gavl_video_source_set_lock_funcs(gavl_video_source_t * src,
  *  \param src A video source
  *  \param free_func Function called with the private data when the source is destroyed
  *
- *  Use this if you don't want to keep a reference to the private data along wit the source
+ *  Use this if you don't want to keep a reference to the private data along with the source
  */
   
 GAVL_PUBLIC void
@@ -217,7 +217,7 @@ gavl_video_source_set_free_func(gavl_video_source_t * src,
 
 
   
-/** \brief Get coversion options of a video source
+/** \brief Get conversion options of a video source
  *  \param s A video source
  *  \returns Conversion options
  */
@@ -347,10 +347,10 @@ void gavl_audio_source_set_pts_offset(gavl_audio_source_t * src, int64_t offset)
  *  \param func Function to get the frames from
  *  \param priv Client data to pass to func
  *  \param src_flags Flags describing the source
- *  \param src preceeding source in the pipeline
+ *  \param src preceding source in the pipeline
  *  \returns A newly created audio source
  *
- *  This will take the destination format of the preceeding source
+ *  This will take the destination format of the preceding source
  *  as the input format
  */
 
@@ -378,7 +378,7 @@ gavl_audio_source_set_lock_funcs(gavl_audio_source_t * src,
  *  \param src A audio source
  *  \param free_func Function called with the private data when the source is destroyed
  *
- *  Use this if you don't want to keep a reference to the private data along wit the source
+ *  Use this if you don't want to keep a reference to the private data along with the source
  */
   
 GAVL_PUBLIC void
@@ -444,7 +444,7 @@ gavl_audio_source_set_dst(gavl_audio_source_t * s, int dst_flags,
  *  copied to the frame you pass.
  *
  *  If the return value is \ref GAVL_SOURCE_AGAIN, you might
- *  have an imcomplete frame. In this case you must call
+ *  have an incomplete frame. In this case you must call
  *  this function again with exactly the same frame argument.
  */
   
@@ -484,7 +484,7 @@ GAVL_PUBLIC
 int gavl_audio_source_read_samples(void*s, gavl_audio_frame_t * frame,
                                    int num_samples);
 
-/** \brief Get coversion options of an audio source
+/** \brief Get conversion options of an audio source
  *  \param s An audio source
  *  \returns Conversion options
  */
@@ -578,7 +578,7 @@ gavl_packet_source_set_lock_funcs(gavl_packet_source_t * src,
  *  \param src A packet source
  *  \param free_func Function called with the private data when the source is destroyed
  *
- *  Use this if you don't want to keep a reference to the private data along wit the source
+ *  Use this if you don't want to keep a reference to the private data along with the source
  */
   
 GAVL_PUBLIC void
@@ -672,7 +672,7 @@ typedef enum
  *  \returns An audio frame where to copy the data
  *
  *  Sinks can use this to pass specially allocated buffers
- *  (e.g. shared or mmaped memory) to the client
+ *  (e.g. shared or mmapped memory) to the client
  */
 
 typedef gavl_audio_frame_t *
@@ -718,7 +718,7 @@ gavl_audio_sink_set_lock_funcs(gavl_audio_sink_t * sink,
  *  \param src A audio sink
  *  \param free_func Function called with the private data when the sink is destroyed
  *
- *  Use this if you don't want to keep a reference to the private data along wit the sink
+ *  Use this if you don't want to keep a reference to the private data along with the sink
  */
   
 GAVL_PUBLIC void
@@ -752,7 +752,7 @@ gavl_audio_sink_get_frame(gavl_audio_sink_t * s);
  *  \param f Frame
  *  \returns \ref GAVL_SINK_ERROR if an error happened, \ref GAVL_SINK_OK else.
  *
- *  The frame must be the same as returned by the preceeding call to
+ *  The frame must be the same as returned by the preceding call to
  *  \ref gavl_audio_sink_get_frame if it was not NULL.
  */
 
@@ -773,7 +773,7 @@ gavl_audio_sink_destroy(gavl_audio_sink_t * s);
  *  \returns A video frame where to copy the data
  *
  *  Sinks can use this to pass specially allocated buffers
- *  (e.g. shared or mmaped memory) to the client
+ *  (e.g. shared or mmapped memory) to the client
  */
 
 typedef gavl_video_frame_t *
@@ -819,7 +819,7 @@ gavl_video_sink_set_lock_funcs(gavl_video_sink_t * sink,
  *  \param src A video sink
  *  \param free_func Function called with the private data when the sink is destroyed
  *
- *  Use this if you don't want to keep a reference to the private data along wit the sink
+ *  Use this if you don't want to keep a reference to the private data along with the sink
  */
   
 GAVL_PUBLIC void
@@ -852,7 +852,7 @@ gavl_video_sink_get_frame(gavl_video_sink_t * s);
  *  \param f Frame
  *  \returns \ref GAVL_SINK_ERROR if an error happened, \ref GAVL_SINK_OK else.
  *
- *  The frame must be the same as returned by the preceeding call to
+ *  The frame must be the same as returned by the preceding call to
  *  \ref gavl_video_sink_get_frame if it was not NULL.
  */
 
@@ -873,7 +873,7 @@ gavl_video_sink_destroy(gavl_video_sink_t * s);
  *  \returns A packet where to copy the data
  *
  *  Sinks can use this to pass specially allocated buffers
- *  (e.g. shared or mmaped memory) to the client
+ *  (e.g. shared or mmapped memory) to the client
  */
 
 typedef gavl_packet_t *
@@ -917,7 +917,7 @@ gavl_packet_sink_set_lock_funcs(gavl_packet_sink_t * sink,
  *  \param src A packet sink
  *  \param free_func Function called with the private data when the sink is destroyed
  *
- *  Use this if you don't want to keep a reference to the private data along wit the sink
+ *  Use this if you don't want to keep a reference to the private data along with the sink
  */
   
 GAVL_PUBLIC void
@@ -946,7 +946,7 @@ gavl_packet_sink_reset(gavl_packet_sink_t * s);
  *  \param p Packet
  *  \returns \ref GAVL_SINK_ERROR if an error happened, \ref GAVL_SINK_OK else.
  *
- *  The frame must be the same as returned by the preceeding call to
+ *  The frame must be the same as returned by the preceding call to
  *  \ref gavl_packet_sink_get_packet if it was not NULL.
  */
 

--- a/include/gavl/gavf.h
+++ b/include/gavl/gavf.h
@@ -108,7 +108,7 @@
    2. As a format, which allows to send multimedia between processes. This implies
       the support of packets in shared memory or dma-buffers.
       
-   It is *not* meant to be a format for achiving movies or music. In particular,
+   It is *not* meant to be a format for archiving movies or music. In particular,
    the fileformat will *not* be garantueed to be compatible between versions.
    You have been warned.
 */
@@ -121,7 +121,7 @@
   len:  64 bit len (or offset in case of GAVFTAIL) as signed, 0 if unknown
   
   Chunks *always* start at 8 byte boundaries (counted from the start of the GAVFPHDR).
-  Preceeding bytes (up to 7) are filled with zeros.
+  Preceding bytes (up to 7) are filled with zeros.
   
   CHUNK("GAVFPHDR")
   len bytes program header (dictionary)
@@ -303,7 +303,7 @@ const gavf_stream_header_t * gavf_get_stream(gavf_t *, int index, int type);
 #endif
 
 
-/* Mark this stream as skipable. */
+/* Mark this stream as skippable. */
 
 GAVL_PUBLIC
 void gavf_stream_set_skip(gavf_t * g, uint32_t id);

--- a/include/gavl/gavl.h
+++ b/include/gavl/gavl.h
@@ -1291,7 +1291,7 @@ void gavl_audio_convert(gavl_audio_converter_t * cnv,
 
 
 /*! \ingroup audio_converter
- *  \brief Set samplerate converstion ratio 
+ *  \brief Set samplerate conversion ratio 
  *  \param cnv An resample only audio converter created with gavl_audio_converter_init_resample
  *  \param ratio  desired src_ratio  
  *
@@ -1730,7 +1730,7 @@ int gavl_rectangle_f_is_empty(const gavl_rectangle_f_t * r);
  * parameter.
  *
  * Zoom is a zoom factor (1.0 = 100 %). Squeeze is a value between -1.0 and 1.0,
- * which changes the apsect ratio in both directions. 0.0 means unchanged.
+ * which changes the aspect ratio in both directions. 0.0 means unchanged.
  *
  * Note that dst_rect might be outside the image dimensions of dst_format. If you
  * don't like this, call \ref gavl_rectangle_crop_to_format_scale afterwards.
@@ -2191,7 +2191,7 @@ const char * gavl_pixelformat_to_short_string(gavl_pixelformat_t pixelformat);
   
 /*! \ingroup video_format
  * \brief Translate a pixelformat name into a pixelformat
- * \param name A string describing the pixelformat (returnd by \ref gavl_pixelformat_to_string)
+ * \param name A string describing the pixelformat (returned by \ref gavl_pixelformat_to_string)
  * \returns The pixelformat or GAVL_PIXELFORMAT_NONE if no match.
  */
 
@@ -2200,7 +2200,7 @@ gavl_pixelformat_t gavl_string_to_pixelformat(const char * name);
 
 /*! \ingroup video_format
  * \brief Translate a short pixelformat name into a pixelformat
- * \param name A string describing the pixelformat (returnd by \ref gavl_pixelformat_to_short_string)
+ * \param name A string describing the pixelformat (returned by \ref gavl_pixelformat_to_short_string)
  * \returns The pixelformat or GAVL_PIXELFORMAT_NONE if no match.
  */
 
@@ -2609,7 +2609,7 @@ gavl_image_orientation_is_transposed(gavl_image_orientation_t orient);
  *
  * This is the standardized method of storing one frame with video data. For planar
  * formats, the first scanline starts at planes[0], subsequent scanlines start in
- * intervalls of strides[0] bytes. For planar formats, planes[0] will contain the
+ * intervals of strides[0] bytes. For planar formats, planes[0] will contain the
  * luminance channel, planes[1] contains Cb (aka U), planes[2] contains Cr (aka V).
  *
  * Video frames are created with \ref gavl_video_frame_create and destroyed with
@@ -2718,7 +2718,7 @@ void gavl_video_frame_clear(gavl_video_frame_t * frame,
 
 /*!
   \ingroup video_frame
-  \brief Fill the frame with a user spefified color
+  \brief Fill the frame with a user specified color
   \param frame A video frame
   \param format Format of the data in the frame
   \param color Color components in RGBA format scaled 0.0 .. 1.0
@@ -2732,7 +2732,7 @@ void gavl_video_frame_fill(gavl_video_frame_t * frame,
 
 /*!
   \ingroup video_frame
-  \brief Fill the frame with the absolute differene of 2 source frames
+  \brief Fill the frame with the absolute difference of 2 source frames
   \param format Format of the data in the frame
   \param dst A video frame
   \param src1 First source frame
@@ -2907,7 +2907,7 @@ void gavl_video_frame_copy_metadata(gavl_video_frame_t * dst,
   \param src_rect Rectangular area in the source, which will be in the destination frame
 
   This fills the pointers of dst from src such that the dst will represent the
-  speficied rectangular area. Note that no data are copied here. This means that
+  specified rectangular area. Note that no data are copied here. This means that
   dst must be created with NULL as the format argument and \ref gavl_video_frame_null
   must be called before destroying dst.
 
@@ -2930,7 +2930,7 @@ void gavl_video_frame_get_subframe(gavl_pixelformat_t pixelformat,
   \param field Field index (0 = top field, 1 = bottom field)
 
   This fills the pointers and strides of the destination frame such that it
-  will represent the speficied field of the source frame.
+  will represent the specified field of the source frame.
   Note that no data are copied here. This means that
   dst must be created with NULL as the format argument and \ref gavl_video_frame_null
   must be called before destroying dst.
@@ -3011,7 +3011,7 @@ void gavl_video_frame_set_planes(gavl_video_frame_t * frame,
   \brief Check if a video frame uses a continuous memory block
   \param format Format of the video data in the frame
   \param frame Video frame
-  \returns 1 if the planes are consequtive in memory and no padding is used, 0 else
+  \returns 1 if the planes are consecutive in memory and no padding is used, 0 else
 
   Use this to check if a frame can be directly serialized or not.
   
@@ -3047,7 +3047,7 @@ int gavl_video_frame_extract_channel(const gavl_video_format_t * format,
   \brief Insert one channel from a grayscale image into a video frame
   \param format Format of the source frame
   \param ch Channel to merge
-  \param src Source frame (grayscale image containing one chanel)
+  \param src Source frame (grayscale image containing one channel)
   \param dst Destination
 
   This inserts one color channel from a grayscale image into a video
@@ -3114,7 +3114,7 @@ void gavl_video_frame_set_from_packet(gavl_video_frame_t * frame,
  * \brief Force deinterlacing
  *
  * This option turns on deinterlacing by the converter in any case (i.e. also if the input format
- * pretends to be progressive or if the ouput format is interlaced).
+ * pretends to be progressive or if the output format is interlaced).
  */
 
 #define GAVL_FORCE_DEINTERLACE (1<<0)
@@ -3737,7 +3737,7 @@ int gavl_video_scaler_init(gavl_video_scaler_t * scaler,
  * which are taken in both left and right from the center pixel, i.e.
  * a value of 1 will result in a 3-tap filter. The coefficients
  * must be given for ALL taps (the convolver does not assume the
- * coeffitients to be symmetric)
+ * coefficients to be symmetric)
  *
  * This function can be called multiple times with one instance. 
  */
@@ -3986,7 +3986,7 @@ typedef struct gavl_image_transform_s gavl_image_transform_t;
  *
  *  All coordinates are in fractional pixels. 0,0 is the
  *  upper left corner. Return negative values or values
- *  larger than the dimesion to signal that a pixel is outside
+ *  larger than the dimension to signal that a pixel is outside
  *  the source image.
  */
  
@@ -4019,7 +4019,7 @@ void gavl_image_transform_destroy(gavl_image_transform_t * t);
  *  \param format Format (can be changed)
  *  \param func Coordinate transform function
  *  \param priv The priv argument for func
- *  \returns 1 if the transform was sucessfully initialized, 0 else.
+ *  \returns 1 if the transform was successfully initialized, 0 else.
  
  * If you enabled multithreading support, func will be called
  * from multiple threads at the same time. Make sure, that it

--- a/include/gavl/gavldsp.h
+++ b/include/gavl/gavldsp.h
@@ -580,7 +580,7 @@ int gavl_dsp_interpolate_video_frame(gavl_dsp_context_t * ctx,
                                       float factor);
 
 /*!
-  \brief Swap endianess an audio frame.
+  \brief Swap endianness an audio frame.
   \param ctx An initialized dsp context
   \param frame An audio frame
   \param format The format of the frame
@@ -597,13 +597,13 @@ int gavl_dsp_audio_frame_swap_endian(gavl_dsp_context_t * ctx,
                                       const gavl_audio_format_t * format);
 
 /*!
-  \brief Swap endianess a video frame.
+  \brief Swap endianness a video frame.
   \param ctx An initialized dsp context
   \param frame A video frame
   \param format The format of the frame
   \returns 1 on success, 0 if an error occurred
 
-  This function swaps endianess for pixelformats, which
+  This function swaps endianness for pixelformats, which
   have multibyte numbers as components.
   For 32 bit long formats with 8 bit components, it swaps the
   pixels as if they were 32 bit integers.

--- a/include/gavl/gavlsocket.h
+++ b/include/gavl/gavlsocket.h
@@ -122,7 +122,7 @@ GAVL_PUBLIC
 int gavl_socket_connect_inet(gavl_socket_address_t*, int timeout);
 
 /* Check if a previous call with zero timeout succeeded
-   Retur value: -1: Error, 0: In Progress, 1. Connected */
+   Return value: -1: Error, 0: In Progress, 1. Connected */
 GAVL_PUBLIC
 int gavl_socket_connect_inet_complete(int fd, int milliseconds);
 

--- a/include/gavl/gavltime.h
+++ b/include/gavl/gavltime.h
@@ -309,7 +309,7 @@ void gavl_timer_set(gavl_timer_t * timer, gavl_time_t t);
  * The returned value itself is meaningless since the
  * timescale depends on the system. Use this only for relative comparisons
  * for benchmarks. A textual description on how the values can be
- * interpreted can be ontained with \ref gavl_benchmark_get_desc
+ * interpreted can be obtained with \ref gavl_benchmark_get_desc
  */
 
 GAVL_PUBLIC

--- a/include/gavl/http.h
+++ b/include/gavl/http.h
@@ -34,7 +34,7 @@
 /*
  *  http utility routines
  *
- *  The main reaon this code is here is because it's shared between gmerlin
+ *  The main reason this code is here is because it's shared between gmerlin
  *  and gmerlin_avdecoder
  */
  

--- a/include/gavl/hw.h
+++ b/include/gavl/hw.h
@@ -167,7 +167,7 @@ gavl_hw_ctx_store(gavl_hw_context_t * ctx, gavl_dictionary_t * dict);
 
 GAVL_PUBLIC gavl_hw_context_t * gavl_hw_ctx_load(const gavl_dictionary_t * dict);
 
-/* Create a HW context with just a type. This function suceeds only for types,
+/* Create a HW context with just a type. This function succeeds only for types,
    which don't require other stuff (e.g. device nodes) for creation */
 
 GAVL_PUBLIC gavl_hw_context_t * gavl_hw_ctx_create(gavl_hw_type_t type);

--- a/include/gavl/hw_egl.h
+++ b/include/gavl/hw_egl.h
@@ -34,7 +34,7 @@ gavl_hw_ctx_create_egl(EGLenum platform,
 
 GAVL_PUBLIC void gavl_hw_egl_swap_buffers(gavl_hw_context_t * ctx);
 
-/* Returned value (zero termiated) must be free()d */
+/* Returned value (zero terminated) must be free()d */
 GAVL_PUBLIC 
 uint32_t * gavl_hw_ctx_egl_get_dma_import_formats(gavl_hw_context_t * ctx);
 

--- a/include/gavl/metadata.h
+++ b/include/gavl/metadata.h
@@ -69,11 +69,11 @@ extern "C" {
 // GAVL_PUBLIC void
 // gavl_dictionary_free(gavl_dictionary_t * m);
 
-/** \brief Initialize structre
+/** \brief Initialize structure
  *  \arg m A metadata structure
  *
  *  Use this if you define a \ref gavl_dictionary_t
- *  structure in unintialized memory (e.g. on the stack)
+ *  structure in uninitialized memory (e.g. on the stack)
  *  before using it.
  */
   
@@ -358,9 +358,9 @@ gavl_metadata_delete_implicit_fields(gavl_dictionary_t * m);
 GAVL_PUBLIC void
 gavl_dictionary_set_string_endian(gavl_dictionary_t * m);
 
-/** \brief Check if endianess needs to be swapped
+/** \brief Check if endianness needs to be swapped
  *  \arg m Metadata
- *  \returns 1 if the stream was generated on a machine with different endianess, 0 else.
+ *  \returns 1 if the stream was generated on a machine with different endianness, 0 else.
  */
 
 GAVL_PUBLIC int

--- a/include/gavl/metatags.h
+++ b/include/gavl/metatags.h
@@ -117,7 +117,7 @@
 
 #define GAVL_META_MTIME       "mtime" // time_t (from stat()) as long
 
-/* Size of the oject in bytes */
+/* Size of the object in bytes */
 #define GAVL_META_TOTAL_BYTES    "totalbytes"
 
 /** \brief Generic year
@@ -451,7 +451,7 @@
 #define GAVL_META_IDX                "idx"         // Index in parent container
 #define GAVL_META_TOTAL              "total"       // Total number (maximum idx + 1)
 #define GAVL_META_SHOW               "Show"        // TV Show, this item belongs to
-#define GAVL_META_SEASON             "Season"      // Season, this episode belongs to (integer but can be non-continuos
+#define GAVL_META_SEASON             "Season"      // Season, this episode belongs to (integer but can be non-continuous
 #define GAVL_META_PODCAST            "Podcast"     // Name of the pocast this item belongs to
 
 #define GAVL_META_EPISODENUMBER      "EPNum"       // Number of the Episode (starting with 1)

--- a/include/gavl/msg.h
+++ b/include/gavl/msg.h
@@ -397,7 +397,7 @@
 
 /* Sink GAVL_MSG_NS_SINK */
 
-/* Timestamps might be discontinous after this call */
+/* Timestamps might be discontinuous after this call */
 #define GAVL_MSG_SINK_RESYNC          1
 
 
@@ -712,7 +712,7 @@ void gavl_msg_get_arg_video_format(gavl_msg_t * msg, int arg,
                                  gavl_video_format_t * format);
 
 
-/** \brief Set a matadata argument
+/** \brief Set a metadata argument
  *  \param msg A message
  *  \param arg Argument index (starting with 0)
  *  \param m Metadata
@@ -727,12 +727,12 @@ void gavl_msg_set_arg_dictionary_nocopy(gavl_msg_t * msg, int arg,
                                         gavl_dictionary_t * m);
 
 
-/** \brief Get a matadata argument
+/** \brief Get a metadata argument
  *  \param msg A message
  *  \param arg Argument index (starting with 0)
  *  \param m Returns dictionary
  *
- *  Don't pass uninitalized memory as dictionary
+ *  Don't pass uninitialized memory as dictionary
  */
 
 GAVL_PUBLIC

--- a/include/gavl/parameter.h
+++ b/include/gavl/parameter.h
@@ -59,7 +59,7 @@ gavl_type_t gavl_parameter_type_to_gavl(gavl_parameter_type_t type);
 
 /* Parameter info (for static initialization) */
 
-/** \brief Parmeter description
+/** \brief Parameter description
  *
  *  Usually, parameter infos are passed around as NULL-terminated arrays.
  */

--- a/include/gavl/peakdetector.h
+++ b/include/gavl/peakdetector.h
@@ -56,9 +56,9 @@ typedef struct gavl_peak_detector_s gavl_peak_detector_t;
 /*! \brief Callback for getting the peaks across all channels
  *  \param priv Client data
  *  \param samples Number of samples of last update call
- *  \param min Minimum value (scaled betwen -1.0 and 1.0)
- *  \param min Maximum value (scaled betwen -1.0 and 1.0)
- *  \param abs Absolute value (scaled betwen 0.0 and 1.0)
+ *  \param min Minimum value (scaled between -1.0 and 1.0)
+ *  \param min Maximum value (scaled between -1.0 and 1.0)
+ *  \param abs Absolute value (scaled between 0.0 and 1.0)
  *
  *  Since 1.5.0
  */
@@ -70,9 +70,9 @@ typedef void (*gavl_update_peak_callback)(void * priv,
 /*! \brief Callback for getting the peaks for all channels separately
  *  \param priv Client data
  *  \param samples Number of samples of last update call
- *  \param min Minimum value (scaled betwen -1.0 and 1.0)
- *  \param min Maximum value (scaled betwen -1.0 and 1.0)
- *  \param abs Absolute value (scaled betwen 0.0 and 1.0)
+ *  \param min Minimum value (scaled between -1.0 and 1.0)
+ *  \param min Maximum value (scaled between -1.0 and 1.0)
+ *  \param abs Absolute value (scaled between 0.0 and 1.0)
  *
  *  Since 1.5.0
  */

--- a/include/gavl/trackinfo.h
+++ b/include/gavl/trackinfo.h
@@ -597,7 +597,7 @@ void gavl_track_get_page_children_end(const gavl_dictionary_t * parent_orig,
                                       gavl_array_t * ret);
 
 /* If the track has more than 1 URIs, set GAVL_META_MULTIVARIANT
-   and sort URIs for descreasing quality (best first) */
+   and sort URIs for decreasing quality (best first) */
    
 // GAVL_PUBLIC
 // void gavl_track_set_multivariant(gavl_dictionary_t * dict);

--- a/include/gavl/utils.h
+++ b/include/gavl/utils.h
@@ -28,9 +28,9 @@
 /** \defgroup utils Utilities
  *  \brief Utility functions
  *
- *  These are some utility functions, which should be used, whereever
+ *  These are some utility functions, which should be used, wherever
  *  possible, instead of their libc counterparts (if any). That's because
- *  they also handle portability issues, ans it's easier to make one single
+ *  they also handle portability issues, and it's easier to make one single
  *  function portable (with \#ifdefs if necessary) and use it throughout
  *  the code.
  *
@@ -45,7 +45,7 @@ GAVL_PUBLIC
 void gavl_dprintf(const char * format, ...)
   __attribute__ ((format (printf, 1, 2)));
 
-/** \brief Dump to stderr with intendation
+/** \brief Dump to stderr with indentation
  *  \param indent How many spaces to prepend
  *  \param format Format (printf compatible)
  */
@@ -97,7 +97,7 @@ char * gavl_sprintf(const char * format,...)
  *  \returns A copy of new_string
  *
  *  This function handles correctly the cases where either argument
- *  is NULL. The emtpy string is treated like a NULL (non-existant)
+ *  is NULL. The empty string is treated like a NULL (non-existent)
  *  string.
  */
 
@@ -126,7 +126,7 @@ char * gavl_strnrep(char * old_string,
  *  \returns A copy of new_string
  *
  *  This function handles correctly the cases where either argument
- *  is NULL. The emtpy string is treated like a NULL (non-existant)
+ *  is NULL. The empty string is treated like a NULL (non-existent)
  *  string.
  */
 
@@ -179,7 +179,7 @@ char * gavl_strtrim(char * str);
  *  \param escape_chars Characters to escape
  *
  *  This returns a newly allocated string with all characters
- *  occuring in escape_chars preceded by a backslash
+ *  occurring in escape_chars preceded by a backslash
  */
 
 GAVL_PUBLIC

--- a/include/samplerate.h
+++ b/include/samplerate.h
@@ -97,7 +97,7 @@ typedef long (*src_callback_t) (void *cb_data, float **data) ;
 SRC_STATE* gavl_src_new (int converter_type, int channels, int *error, int d) ;
 
 /*
-**	Initilisation for callback based API : return an anonymous pointer to the
+**	Initialisation for callback based API : return an anonymous pointer to the
 **	internal state of the converter. Choose a converter from the enums below.
 **	The cb_data pointer can point to any data or be set to NULL. Whatever the
 **	value, when processing, user supplied function "func" gets called with

--- a/include/video.h
+++ b/include/video.h
@@ -34,8 +34,8 @@ struct gavl_video_options_s
   {
   /*
    *  Quality setting from 1 to 5 (0 means undefined).
-   *  3 means Standard C routines or accellerated version with
-   *  equal quality. Lower numbers mean accellerated versions with lower
+   *  3 means Standard C routines or accelerated version with
+   *  equal quality. Lower numbers mean accelerated versions with lower
    *  quality.
    */
   int quality;         

--- a/src/blend_test.c
+++ b/src/blend_test.c
@@ -241,7 +241,7 @@ static gavl_video_frame_t * read_png(const char * filename,
   fclose(file);
   free(rows);
   
-  /* Check wether to set up the converter */
+  /* Check whether to set up the converter */
 
   if(format->pixelformat != pixelformat)
     {

--- a/src/httptest.c
+++ b/src/httptest.c
@@ -53,7 +53,7 @@ int main(int argc, char ** argv)
     return EXIT_FAILURE;
     }
   
-  gavl_log(GAVL_LOG_INFO, LOG_DOMAIN, "Downladed http body %d bytes", buf.len);
+  gavl_log(GAVL_LOG_INFO, LOG_DOMAIN, "Downloaded http body %d bytes", buf.len);
   gavl_buffer_free(&buf);
   
   }

--- a/src/pngutil.c
+++ b/src/pngutil.c
@@ -234,7 +234,7 @@ gavl_video_frame_t * read_png(const char * filename,
   fclose(file);
   free(rows);
   
-  /* Check wether to set up the converter */
+  /* Check whether to set up the converter */
 
   if((pixelformat != GAVL_PIXELFORMAT_NONE) && (format->pixelformat != pixelformat))
     {

--- a/src/scaletest.c
+++ b/src/scaletest.c
@@ -271,7 +271,7 @@ static gavl_video_frame_t * read_png(const char * filename,
   fclose(file);
   free(rows);
   
-  /* Check wether to set up the converter */
+  /* Check whether to set up the converter */
 
   if(format->pixelformat != pixelformat)
     {


### PR DESCRIPTION
Found via:
`codespell -q 3 -S "./include/language_table.h,./gavl/countrycodes.c,./utils/lan guage-codes-full.csv" -L bu,doubleclick,indx,parm,sav`